### PR TITLE
Updated MapChange signature to be compatible with 5.26

### DIFF
--- a/AntiRush.as
+++ b/AntiRush.as
@@ -701,7 +701,7 @@ void MapInit()
 	g_Scheduler.SetTimeout("init", 2);
 }
 
-HookReturnCode MapChange()
+HookReturnCode MapChange(const string& in szNextMap)
 {
 	changelevelButs.resize(0);
 	changelevelEnts.resize(0);


### PR DESCRIPTION
Problem:
Anti-rush fails to detect level change ents and reports "map change sequence is too complex".

Fix:
Updated MapChange hook to the new signature that sven coop 5.26 requires. Tested and appears to work.

Strangely there was no error messages in the logs about the invalid signature.